### PR TITLE
Correct scope used to access the evidence service

### DIFF
--- a/crown-court-proceeding/src/main/resources/application.yaml
+++ b/crown-court-proceeding/src/main/resources/application.yaml
@@ -70,7 +70,7 @@ spring:
             client-id: ${EVIDENCE_API_OAUTH_CLIENT_ID}
             client-secret: ${EVIDENCE_API_OAUTH_CLIENT_SECRET}
             authorization-grant-type: client_credentials
-            scope: READ_WRITE
+            scope: evidence/standard
       resource-server:
         jwt:
           issuer-uri: ${crown-court-proceeding.security.issuer-uri}


### PR DESCRIPTION
Fix bug preventing CCP contacting the evidence service.