### PR TITLE
LCAM 1254 Remove Validation For Hardship Review Result

### DIFF
--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderService.java
@@ -86,7 +86,7 @@ public class RepOrderService {
         if (((initAssessmentResult == InitAssessmentResult.PASS && initAssessmentStatus == CurrentStatus.COMPLETE)
                 || (fullAssessmentResult == FullAssessmentResult.PASS && fullAssessmentStatus == CurrentStatus.COMPLETE)
                 || (hardshipOverview != null && (hardshipOverview.getReviewResult() == ReviewResult.PASS
-                && hardshipOverview.getAssessmentStatus() == CurrentStatus.COMPLETE)))
+                    && hardshipOverview.getAssessmentStatus() == CurrentStatus.COMPLETE)))
                 && isValidCaseType) {
             return Constants.GRANTED_PASSED_MEANS_TEST;
         } else if ((initAssessmentResult == InitAssessmentResult.FAIL && initAssessmentStatus == CurrentStatus.COMPLETE)

--- a/crown-court-proceeding/src/main/resources/schemas/common/apiHardshipOverview.json
+++ b/crown-court-proceeding/src/main/resources/schemas/common/apiHardshipOverview.json
@@ -16,5 +16,5 @@
     }
   },
   "additionalProperties": false,
-  "required": ["reviewResult", "assessmentStatus"]
+  "required": ["assessmentStatus"]
 }

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
@@ -13,10 +13,7 @@ import uk.gov.justice.laa.crime.crowncourt.common.Constants;
 import uk.gov.justice.laa.crime.crowncourt.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.crowncourt.dto.CrownCourtDTO;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.RepOrderDTO;
-import uk.gov.justice.laa.crime.crowncourt.model.ApiCalculateEvidenceFeeResponse;
-import uk.gov.justice.laa.crime.crowncourt.model.ApiCrownCourtSummary;
-import uk.gov.justice.laa.crime.crowncourt.model.ApiIOJAppeal;
-import uk.gov.justice.laa.crime.crowncourt.model.ApiPassportAssessment;
+import uk.gov.justice.laa.crime.crowncourt.model.*;
 import uk.gov.justice.laa.crime.enums.*;
 
 import java.util.ArrayList;
@@ -361,13 +358,28 @@ class RepOrderServiceTest {
     }
 
     @Test
-    void givenHardshipOverviewResultIsNull_whenGetDecisionByFinAssessmentIsInvoked_thenNullIsReturned() {
+    void givenHardshipOverviewIsNull_whenGetDecisionByFinAssessmentIsInvoked_thenNullIsReturned() {
         CrownCourtDTO requestDTO = TestModelDataBuilder.getCrownCourtDTO();
         setUpFinAssessment(
                 requestDTO, CurrentStatus.COMPLETE, null,
                 InitAssessmentResult.FULL.getResult(), null, null
         );
         requestDTO.getFinancialAssessment().setHardshipOverview(null);
+
+        assertThat(repOrderService.getDecisionByFinAssessment(requestDTO, null, true))
+                .isNull();
+    }
+
+    @Test
+    void givenHardshipOverviewResultIsNull_whenGetDecisionByFinAssessmentIsInvoked_thenNullIsReturned() {
+        CrownCourtDTO requestDTO = TestModelDataBuilder.getCrownCourtDTO();
+        setUpFinAssessment(
+                requestDTO, CurrentStatus.COMPLETE, null,
+                InitAssessmentResult.FULL.getResult(), null, null
+        );
+        ApiHardshipOverview hardshipOverview = new ApiHardshipOverview().withAssessmentStatus(CurrentStatus.COMPLETE);
+        requestDTO.getFinancialAssessment().setHardshipOverview(hardshipOverview);
+
         assertThat(repOrderService.getDecisionByFinAssessment(requestDTO, null, true))
                 .isNull();
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/jira/software/projects/LCAM/boards/881?selectedIssue=LCAM-1254)

Investigated the above live issue and discovered that the bad request was returned from CCP as MAAT was passing a NULL reviewResult in the hardshipOverview object as part of the call and in CCP this is specified as a required field.
The NULL reviewResult is written to the database when a caseworker completes a hardship review without adding any details which is a valid scenario that they perform, usually when they want to flag that a hardship review needs doing on a case but they dont have the required documents to complete it fully.
Usually this NULL result row is replaced soon after anyway when another hardship review is done with the appropriate details entered. However in some rare cases the NULL result is never replaced. Hence the bug reported. 

I've removed the validation for reviewResult so CCP can accept a potentially NULL reviewResult on the occasion when it is submitted to CCP and added a new unit test scenario to cover this highlighted issue.

See also [sub PR](https://github.com/ministryofjustice/laa-maat-orchestration/pull/105) for the realignment of the hardship overview schema in orchestrator following changes to it here.

## Checklist

Before you ask people to review this PR:

- [x] Tests should be passing: `./gradlew test`
- [x] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [x] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [x] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [x] You should have checked that the commit messages say why the change was made.
