### PR TITLE
LCAM-1558|Null check before setting the decision date

### DIFF
--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderService.java
@@ -18,6 +18,7 @@ import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.IOJAppealDTO;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.RepOrderCCOutcomeDTO;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.RepOrderDTO;
 import uk.gov.justice.laa.crime.enums.*;
+import uk.gov.justice.laa.crime.util.DateUtil;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -202,7 +203,7 @@ public class RepOrderService {
         if (StringUtils.isNotBlank(repOrderDecision) && crownCourtSummary.getRepOrderDate() == null) {
             switch (requestDTO.getCaseType()) {
                 case INDICTABLE -> crownCourtSummary.setRepOrderDate(
-                        requestDTO.getMagsDecisionResult().getDecisionDate().atStartOfDay()
+                        DateUtil.convertDateToDateTime(requestDTO.getMagsDecisionResult().getDecisionDate())
                 );
                 case EITHER_WAY -> crownCourtSummary.setRepOrderDate(
                         determineMagsRepOrderDate(requestDTO, repOrderDecision)
@@ -230,7 +231,7 @@ public class RepOrderService {
 
         if (MagCourtOutcome.COMMITTED_FOR_TRIAL.equals(requestDTO.getMagCourtOutcome())) {
             if (DecisionReason.GRANTED.equals(decisionReason)) {
-                return requestDTO.getMagsDecisionResult().getDecisionDate().atStartOfDay();
+                return DateUtil.convertDateToDateTime(requestDTO.getMagsDecisionResult().getDecisionDate());
             } else if ((decisionReason != null && failedDecisionReasons.contains(decisionReason)) ||
                     Constants.REFUSED_INELIGIBLE.equals(repOrderDecision)) {
                 return requestDTO.getCommittalDate();


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1558)

The decision date can be null on the application, hence checking for not null before populating the cc rep order date from decision date.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.
