### PR TITLE
Upgrade spring framework version to address snyk reported security vulnerability

### DIFF
--- a/crown-court-proceeding/build.gradle
+++ b/crown-court-proceeding/build.gradle
@@ -3,8 +3,8 @@ plugins {
     id "jacoco"
     id "org.sonarqube" version "4.0.0.2929"
     id "info.solidsoft.pitest" version "1.9.11"
-    id "org.springframework.boot" version "3.1.5"
-    id 'io.spring.dependency-management' version '1.1.4'
+    id "org.springframework.boot" version "3.3.5"
+    id "io.spring.dependency-management" version "1.1.6"
 }
 
 group = "uk.gov.justice.laa.crime"
@@ -18,9 +18,9 @@ def versions = [
         pitest                           : "1.4.10",
         amazonSQSVersion                 : "2.1.1",
         springFrameworkCloudVersion      : "3.0.1",
-        crimeCommonsClasses              : "3.29.0",
-        commonsRestClient                : "3.4.0",
-        commonsModSchemas                : "1.10.0",
+        crimeCommonsClasses              : "3.33.0",
+        commonsRestClient                : "3.18.0",
+        commonsModSchemas                : "1.17.0",
         mockitoInlineVersion             : "5.2.0",
         wmStubRunnerVersion              : "4.0.1",
         springDocWebMVCVersion           : "2.1.0",

--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/dto/CrownCourtDTO.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/dto/CrownCourtDTO.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.crowncourt.dto;
 
 import lombok.Builder;
 import lombok.Data;
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.*;
 import uk.gov.justice.laa.crime.enums.CaseType;
 import uk.gov.justice.laa.crime.enums.EvidenceFeeLevel;

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/data/builder/TestModelDataBuilder.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/data/builder/TestModelDataBuilder.java
@@ -2,6 +2,7 @@ package uk.gov.justice.laa.crime.crowncourt.data.builder;
 
 import org.springframework.stereotype.Component;
 import uk.gov.justice.laa.crime.common.model.common.ApiCrownCourtOutcome;
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.*;
 import uk.gov.justice.laa.crime.common.model.proceeding.request.ApiCalculateEvidenceFeeRequest;
 import uk.gov.justice.laa.crime.common.model.proceeding.request.ApiDetermineMagsRepDecisionRequest;

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.justice.laa.crime.common.model.common.ApiUserSession;
 import uk.gov.justice.laa.crime.common.model.proceeding.common.*;
 import uk.gov.justice.laa.crime.crowncourt.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.crowncourt.dto.CrownCourtDTO;


### PR DESCRIPTION
In order to address the recently reported snyk security vulnerability upgrading the spring framework version to 3.3.5. 
To support this upgrade the following dependencies are also updated.

Upgrade crime-commons-spring-boot-starter-rest-client to 3.18.0
Upgrade crime-commons-mod-schemas to 1.17.0
Upgrade crime-commons-classes to 3.33.0

Co-authored with @venkat980 

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1630)