### PR TITLE
Fix security vulnerability in spring-security-crypto

### DIFF
--- a/crown-court-proceeding/build.gradle
+++ b/crown-court-proceeding/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id "jacoco"
     id "org.sonarqube" version "4.0.0.2929"
     id "info.solidsoft.pitest" version "1.9.11"
-    id "org.springframework.boot" version "3.3.5"
+    id "org.springframework.boot" version "3.3.7"
     id "io.spring.dependency-management" version "1.1.6"
 }
 

--- a/crown-court-proceeding/build.gradle
+++ b/crown-court-proceeding/build.gradle
@@ -31,7 +31,9 @@ def versions = [
         testcontainersJunitjupiterVersion: "1.19.0",
         postgresqlVersion                : "42.7.2",
         tomcatEmbedCoreVersion           : "10.1.34",
-        notifyClientVersion              : "5.1.0-RELEASE"
+        notifyClientVersion              : "5.1.0-RELEASE",
+        oauth2ResourceServer             : "3.4.1",
+        securityCrypto                   : "6.4.4"
 ]
 
 java {
@@ -66,8 +68,9 @@ dependencies {
     implementation "org.apache.tomcat.embed:tomcat-embed-core:$versions.tomcatEmbedCoreVersion"
 
     implementation "org.springframework.boot:spring-boot-starter-validation"
-    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
+    implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server:$versions.oauth2ResourceServer"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation "org.springframework.security:spring-security-crypto:$versions.securityCrypto"
 
     implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:$versions.springFrameworkCloudVersion"
     implementation "org.springframework:spring-jms"


### PR DESCRIPTION
This PR fixes the [recently published security vulnerability] (https://security.snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORKSECURITY-9486467) in `spring-security-crypto` by forcibly bumping the dependency up to version `6.4.4`.

This PR also bumps Spring Boot from `3.3.5` to `3.3.7` to address vulnerabilities in `org.springframework.security:spring-security-core` version `6.3.4`.

Spring Boot version `3.4.4` does patch `spring-security-crypto` to this same version, but in order to upgrade Spring Boot, Crime Commons modules also need to be upgraded at the same time, which has more potential to cause problems elsewhere. In that context and to ensure that the Orchestration Service can be as quickly fixed to allow deployments once again, this temporary fix is made in this PR until such time as Spring Boot is upgraded to `3.4.4`.

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1788)