### PR TITLE
LCAM-1789: Fix Failing Evidence Fee Test Scenarios in the Functional Test Suite

### DIFF
--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedController.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedController.java
@@ -4,27 +4,28 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.service.ProsecutionConcludedDataService;
 
 @Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/internal/v1/proceedings/prosecution-concluded/{maatId}/messages")
-@Tag(name = "Prosecution concluded", description = "Rest API for Prosecution concluded")
+@Tag(name = "Prosecution concluded", description = "Rest API for prosecution concluded messages")
 public class ProsecutionConcludedController {
 
-    private final ProsecutionConcludedDataService prosecutionConcludedDataService;
+    private final ProsecutionConcludedDataService concludedDataService;
 
     @GetMapping(value = "/count", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Retrieve Prosecution Concluded Count")
     public ResponseEntity<Object> getCountByMaatIdAndStatus(@PathVariable int maatId,
-                                                            @RequestParam(value = "status", defaultValue = "PENDING") String  status) {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(prosecutionConcludedDataService.getCountByMaatIdAndStatus(maatId, status));
-        return ResponseEntity.ok().headers(responseHeaders).build();
+            @RequestParam(value = "status", defaultValue = "PENDING") String status) {
+        return ResponseEntity.ok(concludedDataService.getCountByMaatIdAndStatus(maatId, status));
     }
 }

--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedController.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedController.java
@@ -13,16 +13,13 @@ import uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.service.Prosecu
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/internal/v1/proceedings/prosecution/scheduler")
+@RequestMapping("api/internal/v1/proceedings/prosecution-concluded/{maatId}/messages")
 @Tag(name = "Prosecution concluded", description = "Rest API for Prosecution concluded")
 public class ProsecutionConcludedController {
 
     private final ProsecutionConcludedDataService prosecutionConcludedDataService;
 
-    @RequestMapping(value = "/{maatId}",
-            method = {RequestMethod.HEAD},
-            produces = MediaType.APPLICATION_JSON_VALUE
-    )
+    @GetMapping(value = "/count", produces = MediaType.APPLICATION_JSON_VALUE)
     @Operation(description = "Retrieve Prosecution Concluded Count")
     public ResponseEntity<Object> getCountByMaatIdAndStatus(@PathVariable int maatId,
                                                             @RequestParam(value = "status", defaultValue = "PENDING") String  status) {

--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/CourtDataAPIService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/CourtDataAPIService.java
@@ -103,25 +103,25 @@ public class CourtDataAPIService {
     }
 
     public long getOffenceNewOffenceCount(int caseId, String offenceId) {
-        ResponseEntity<Void> response = maatAPIClient.head(
+        Integer response = maatAPIClient.get(
+                new ParameterizedTypeReference<>() {},
                 configuration.getMaatApi().getOffenceEndpoints().getOffenceCountUrl(),
-                emptyMap(),
                 offenceId,
                 caseId
         );
         log.info(RESPONSE_STRING, response);
-        return response.getHeaders().getContentLength();
+        return response;
     }
 
     public long getWQOffenceNewOffenceCount(int caseId, String offenceId) {
-        ResponseEntity<Void> response = maatAPIClient.head(
+        Integer response = maatAPIClient.get(
+                new ParameterizedTypeReference<>() {},
                 configuration.getMaatApi().getWqOffenceEndpoints().getWqOffenceCountUrl(),
-                emptyMap(),
                 offenceId,
                 caseId
         );
         log.info(RESPONSE_STRING, response);
-        return response.getHeaders().getContentLength();
+        return response;
     }
 
     public List<Integer> findResultsByWQTypeSubType(int wqType, int subTypeCode) {

--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/ProsecutionConcludedDataService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/ProsecutionConcludedDataService.java
@@ -15,8 +15,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
-@Service
 @Slf4j
+@Service
 @RequiredArgsConstructor
 public class ProsecutionConcludedDataService {
 

--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataService.java
@@ -86,6 +86,7 @@ public class MaatCourtDataService {
                 repId
         );
         log.debug(RESPONSE_STRING, response);
-        return response.getHeaders().getContentLength();
+        String header = response.getHeaders().getFirst("X-Total-Records");
+        return header == null ? 0 : Long.parseLong(header);
     }
 }

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/integration/CrownCourtProceedingIntegrationTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/integration/CrownCourtProceedingIntegrationTest.java
@@ -52,25 +52,25 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
             "Cannot have Crown Court outcome without Mags Court outcome";
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
                 .addFilter(springSecurityFilterChain).build();
     }
 
     @Test
-    void givenAEmptyContent_whenProcessRepOrderIsInvoked_thenFailsBadRequest() throws Exception {
+    void givenEmptyContent_whenProcessRepOrderIsInvoked_thenFailsBadRequest() throws Exception {
         mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.POST, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest());
     }
 
     @Test
-    void givenAEmptyOAuthToken_whenCreateAssessmentIsInvoked_thenFailsUnauthorizedAccess() throws Exception {
+    void givenEmptyOAuthToken_whenCreateAssessmentIsInvoked_thenFailsUnauthorizedAccess() throws Exception {
         mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.POST, "{}", ENDPOINT_URL, false))
                 .andExpect(status().isUnauthorized()).andReturn();
     }
 
     @Test
-    void givenAInvalidContent_whenProcessRepOrderIsInvoked_thenFailsBadRequest() throws Exception {
+    void givenInvalidContent_whenProcessRepOrderIsInvoked_thenFailsBadRequest() throws Exception {
         var apiUpdateApplicationRequest =
                 TestModelDataBuilder.getApiProcessRepOrderRequest(!IS_VALID);
         var applicationRequestJson = objectMapper.writeValueAsString(apiUpdateApplicationRequest);
@@ -79,7 +79,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidContent_whenApiResponseIsError_thenProcessRepOrderIsFails() throws Exception {
+    void givenValidContent_whenApiResponseIsError_thenProcessRepOrderIsFails() throws Exception {
         var apiProcessRepOrderRequest = TestModelDataBuilder.getApiProcessRepOrderRequest(Boolean.TRUE);
         apiProcessRepOrderRequest.setCaseType(CaseType.APPEAL_CC);
 
@@ -99,7 +99,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidEitherWayCaseTypeContent_whenProcessRepOrderIsInvoked_thenSuccess() throws Exception {
+    void givenValidEitherWayCaseTypeContent_whenProcessRepOrderIsInvoked_thenSuccess() throws Exception {
         MvcResult result = mvc.perform(RequestBuilderUtils.buildRequestGivenContent(
                         HttpMethod.POST, objectMapper.writeValueAsString(
                                 TestModelDataBuilder.getApiProcessRepOrderRequest(Boolean.TRUE)), ENDPOINT_URL))
@@ -110,7 +110,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidAppealCCContent_whenProcessRepOrderIsInvoked_thenSuccess() throws Exception {
+    void givenValidAppealCCContent_whenProcessRepOrderIsInvoked_thenSuccess() throws Exception {
         var apiProcessRepOrderRequest = TestModelDataBuilder.getApiProcessRepOrderRequest(Boolean.TRUE);
         apiProcessRepOrderRequest.setCaseType(CaseType.APPEAL_CC);
         var processRepOrderRequestJson = objectMapper.writeValueAsString(apiProcessRepOrderRequest);
@@ -126,21 +126,21 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
 
 
     @Test
-    void givenAEmptyContent_whenUpdateApplicationIsInvoked_thenFailsBadRequest() throws Exception {
+    void givenEmptyContent_whenUpdateApplicationIsInvoked_thenFailsBadRequest() throws Exception {
         mvc.perform(RequestBuilderUtils.buildRequestGivenContent(
                         HttpMethod.PUT, "{}", ENDPOINT_URL))
                 .andExpect(status().isBadRequest()).andReturn();
     }
 
     @Test
-    void givenAEmptyOAuthToken_whenUpdateApplicationIsInvoked_thenFailsUnauthorizedAccess() throws Exception {
+    void givenEmptyOAuthToken_whenUpdateApplicationIsInvoked_thenFailsUnauthorizedAccess() throws Exception {
         mvc.perform(RequestBuilderUtils.buildRequestGivenContent(
                         HttpMethod.PUT, "{}", ENDPOINT_URL, Boolean.FALSE))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void givenAInvalidContent_whenUpdateApplicationIsInvoked_thenFailsBadRequest() throws Exception {
+    void givenInvalidContent_whenUpdateApplicationIsInvoked_thenFailsBadRequest() throws Exception {
         mvc.perform(RequestBuilderUtils.buildRequestGivenContent(
                         HttpMethod.PUT, objectMapper.writeValueAsString(
                                 TestModelDataBuilder.getApiUpdateApplicationRequest(Boolean.FALSE)), ENDPOINT_URL))
@@ -165,7 +165,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidContent_whenUpdateApplicationIsInvoked_thenUpdateApplicationIsSuccess() throws Exception {
+    void givenValidContent_whenUpdateApplicationIsInvoked_thenUpdateApplicationIsSuccess() throws Exception {
         var updateApplicationResponse = TestModelDataBuilder.getApiUpdateApplicationResponse();
         ApiUpdateApplicationRequest
                 apiUpdateApplicationRequest = TestModelDataBuilder.getApiUpdateApplicationRequest(Boolean.TRUE);
@@ -198,7 +198,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAIndictableCaseTypeAndMagistratesOutcomeIsEmpty_whenUpdateIsInvoked_thenFailsBadRequest() throws Exception {
+    void givenIndictableCaseTypeAndMagistratesOutcomeIsEmpty_whenUpdateIsInvoked_thenFailsBadRequest() throws Exception {
         ApiUpdateCrownCourtRequest apiUpdateCrownCourtRequest = TestModelDataBuilder.getApiUpdateCrownCourtRequest(Boolean.TRUE);
         apiUpdateCrownCourtRequest.setCaseType(CaseType.INDICTABLE);
         apiUpdateCrownCourtRequest.setMagCourtOutcome(null);
@@ -221,7 +221,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidContent_whenApiResponseIsError_thenUpdateIsFails() throws Exception {
+    void givenValidContent_whenApiResponseIsError_thenUpdateIsFails() throws Exception {
         ApiUpdateCrownCourtRequest apiUpdateCrownCourtRequest = TestModelDataBuilder.getApiUpdateCrownCourtRequest(Boolean.TRUE);
         stubForOAuth();
 
@@ -236,7 +236,7 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
     }
 
     @Test
-    void givenAValidContent_whenUpdateIsInvoked_thenUpdateIsSuccess() throws Exception {
+    void givenValidContent_whenUpdateIsInvoked_thenUpdateIsSuccess() throws Exception {
 
         ApiUpdateCrownCourtRequest apiUpdateCrownCourtRequest = TestModelDataBuilder.getApiUpdateCrownCourtRequest(Boolean.TRUE);
         apiUpdateCrownCourtRequest.setCaseType(CaseType.APPEAL_CC);
@@ -277,8 +277,8 @@ class CrownCourtProceedingIntegrationTest extends WiremockIntegrationTest {
         wiremock.stubFor(head(anyUrl())
                 .willReturn(
                         WireMock.ok()
+                                .withHeader("X-Total-Records", String.valueOf(0))
                                 .withHeader("Content-Type", String.valueOf(MediaType.APPLICATION_JSON))
-                                .withHeader("Content-Length", "0")
                 )
         );
 

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedControllerTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/controller/ProsecutionConcludedControllerTest.java
@@ -2,7 +2,6 @@ package uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.controller;
 
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
@@ -10,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -18,7 +16,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.justice.laa.crime.commons.tracing.TraceIdHandler;
 import uk.gov.justice.laa.crime.crowncourt.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.service.ProsecutionConcludedDataService;
-import uk.gov.justice.laa.crime.crowncourt.service.DeadLetterMessageService;
 import uk.gov.justice.laa.crime.crowncourt.staticdata.enums.CaseConclusionStatus;
 
 @DirtiesContext
@@ -27,7 +24,7 @@ import uk.gov.justice.laa.crime.crowncourt.staticdata.enums.CaseConclusionStatus
 class ProsecutionConcludedControllerTest {
 
     private static final String COUNT_ENDPOINT_URL =
-            "api/internal/v1/proceedings/prosecution-concluded/%s/messages/count";
+            "/api/internal/v1/proceedings/prosecution-concluded/%s/messages/count";
 
     @Autowired
     private MockMvc mvc;
@@ -38,27 +35,24 @@ class ProsecutionConcludedControllerTest {
     @MockBean
     private TraceIdHandler traceIdHandler;
 
-    @MockBean
-    private DeadLetterMessageService deadLetterMessageService;
-
     @Test
     void givenIncorrectParameters_whenGetCountByMaatIdAndStatusIsInvoked_thenErrorIsThrown()
             throws Exception {
-        mvc.perform(MockMvcRequestBuilders.head(COUNT_ENDPOINT_URL)
+        mvc.perform(MockMvcRequestBuilders.get(String.format(COUNT_ENDPOINT_URL, "invalid"))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isNotFound());
+                .andExpect(status().isBadRequest());
     }
 
     @Test
-    void givenAValidParameters_whenGetCountByMaatIdAndStatusIsInvoked_thenReturnCount()
+    void givenValidParameters_whenGetCountByMaatIdAndStatusIsInvoked_thenReturnCount()
             throws Exception {
         when(service.getCountByMaatIdAndStatus(TestModelDataBuilder.TEST_REP_ID,
                 CaseConclusionStatus.PENDING.name())).thenReturn(1L);
-        mvc.perform(MockMvcRequestBuilders.head(
+        mvc.perform(MockMvcRequestBuilders.get(
                         String.format(COUNT_ENDPOINT_URL, TestModelDataBuilder.TEST_REP_ID)
                                 + "?status=" + CaseConclusionStatus.PENDING.name()))
                 .andExpect(status().isOk())
-                .andExpect(content().string(""))
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, "1"));
+                .andExpect(content().string(String.valueOf(1)))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 }

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/integration/ProsecutionConcludedIntegrationTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/integration/ProsecutionConcludedIntegrationTest.java
@@ -1,23 +1,29 @@
 package uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.integration;
 
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.web.FilterChainProxy;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 import uk.gov.justice.laa.crime.crowncourt.data.builder.TestModelDataBuilder;
+import uk.gov.justice.laa.crime.crowncourt.entity.ProsecutionConcludedEntity;
 import uk.gov.justice.laa.crime.crowncourt.integration.WiremockIntegrationTest;
 import uk.gov.justice.laa.crime.crowncourt.repository.ProsecutionConcludedRepository;
 import uk.gov.justice.laa.crime.crowncourt.staticdata.enums.CaseConclusionStatus;
 import uk.gov.justice.laa.crime.util.RequestBuilderUtils;
-
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 class ProsecutionConcludedIntegrationTest extends WiremockIntegrationTest {
 
@@ -35,51 +41,52 @@ class ProsecutionConcludedIntegrationTest extends WiremockIntegrationTest {
     @Autowired
     private ProsecutionConcludedRepository repository;
 
-    private static final String ENDPOINT_URL = "/api/internal/v1/proceedings/prosecution/scheduler";
-    private static final Integer INVAID_MAAT_ID = 1111;
+    private static final String COUNT_ENDPOINT_URL =
+            "/api/internal/v1/proceedings/prosecution-concluded/%s/messages/count";
+    private static final Integer NON_EXISTENT_REP_ID = 1111;
 
     @BeforeEach
-    public void setup() {
+    void setup() {
         this.mvc = MockMvcBuilders.webAppContextSetup(this.webApplicationContext)
                 .addFilter(springSecurityFilterChain).build();
-        repository.save(TestModelDataBuilder.getProsecutionConcludedEntity());
+        ProsecutionConcludedEntity prosecutionConcludedEntity =
+                TestModelDataBuilder.getProsecutionConcludedEntity();
+        repository.save(prosecutionConcludedEntity);
     }
 
     @Test
-    void givenAInvalidParameter_whenGetCountByMaatIdAndStatusIsInvoked_thenErrorIsThrown() throws Exception {
-        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.HEAD, "{}", ENDPOINT_URL, true))
+    void givenInvalidParameters_whenGetCountByMaatIdAndStatusIsInvoked_thenErrorIsThrown()
+            throws Exception {
+        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.GET, "{}",
+                        COUNT_ENDPOINT_URL, true))
                 .andExpect(status().is4xxClientError());
     }
 
-    @Test
-    void givenAInvalidStatusParameter_whenGetNewOffenceCountIsInvoked_thenZeroIsReturned() throws Exception {
-        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.HEAD, "{}", ENDPOINT_URL
-                        + "/" + TestModelDataBuilder.TEST_REP_ID + "?status=" + CaseConclusionStatus.PROCESSED.name()))
+    @ParameterizedTest
+    @MethodSource("countUrlProvider")
+    void givenNonExistingMaatId_whenGetNewOffenceCountIsInvoked_thenZeroIsReturned(String url,
+            int expectedCount) throws Exception {
+        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.GET, "{}", url))
                 .andExpect(status().isOk())
-                .andExpect(content().string(""))
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, "0"));
+                .andExpect(content().string(String.valueOf(expectedCount)))
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
     }
 
-    @Test
-    void givenAInvalidMaatIdParameter_whenGetNewOffenceCountIsInvoked_thenZeroIsReturned1() throws Exception {
-        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.HEAD, "{}", ENDPOINT_URL
-                        + "/" + INVAID_MAAT_ID))
-                .andExpect(status().isOk())
-                .andExpect(content().string(""))
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, "0"));
-    }
-
-    @Test
-    void givenAValidParameter_whenGetNewOffenceCountIsInvoked_thenCountIsReturned() throws Exception {
-        mvc.perform(RequestBuilderUtils.buildRequestGivenContent(HttpMethod.HEAD, "{}", ENDPOINT_URL
-                        + "/" + TestModelDataBuilder.TEST_REP_ID, true))
-                .andExpect(status().isOk())
-                .andExpect(content().string(""))
-                .andExpect(header().string(HttpHeaders.CONTENT_LENGTH, "1"));
+    private static Stream<Arguments> countUrlProvider() {
+        return Stream.of(
+                // Scenario 1: Valid repId but with a status that doesn't match any records returns 0.
+                Arguments.of(String.format(COUNT_ENDPOINT_URL, TestModelDataBuilder.TEST_REP_ID)
+                        + "?status=" + CaseConclusionStatus.PROCESSED.name(), 0),
+                // Scenario 2: A non-existent repId returns 0.
+                Arguments.of(String.format(COUNT_ENDPOINT_URL, NON_EXISTENT_REP_ID), 0),
+                // Scenario 3: Valid repId but with default status returns 1.
+                Arguments.of(String.format(COUNT_ENDPOINT_URL, TestModelDataBuilder.TEST_REP_ID),
+                        1)
+        );
     }
 
     @AfterEach
-    public void clearUp() {
+    void clearUp() {
         repository.deleteAll();
     }
 }

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/CourtDataAPIServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/service/CourtDataAPIServiceTest.java
@@ -1,5 +1,17 @@
 package uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,8 +19,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
 import uk.gov.justice.laa.crime.crowncourt.config.MockServicesConfiguration;
 import uk.gov.justice.laa.crime.crowncourt.config.ServicesConfiguration;
@@ -19,13 +29,6 @@ import uk.gov.justice.laa.crime.crowncourt.model.UpdateCCOutcome;
 import uk.gov.justice.laa.crime.crowncourt.model.UpdateSentenceOrder;
 import uk.gov.justice.laa.crime.crowncourt.prosecution_concluded.model.ProsecutionConcluded;
 import uk.gov.justice.laa.crime.crowncourt.service.CourtDataAdapterService;
-
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
@@ -119,25 +122,9 @@ class CourtDataAPIServiceTest {
     }
 
     @Test
-    void givenAInvalidParameter_whenGetOffenceNewOffenceCountIsInvoked_thenNullIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(0);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
-        long offenceCount = courtDataAPIService.getOffenceNewOffenceCount(
-                TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
-        );
-        assertThat(offenceCount).isZero();
-    }
-
-    @Test
-    void givenAInvalidParameter_whenGetOffenceNewOffenceCountIsInvoked_thenEmptyIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(0);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
+    void givenAInvalidParameter_whenGetOffenceNewOffenceCountIsInvoked_thenReturnZero() {
+        when(maatAPIClient.get(any(), anyString(), any(Object[].class)))
+                .thenReturn(0);
         long offenceCount = courtDataAPIService.getOffenceNewOffenceCount(
                 TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
         );
@@ -146,37 +133,18 @@ class CourtDataAPIServiceTest {
 
     @Test
     void givenAValidParameter_whenGetOffenceNewOffenceCountIsInvoked_thenResponseIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(4);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
+        when(maatAPIClient.get(any(), anyString(), any(Object[].class)))
+                .thenReturn(5);
         long offenceCount = courtDataAPIService.getOffenceNewOffenceCount(
                 TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
         );
-        assertThat(offenceCount).isEqualTo(4);
+        assertThat(offenceCount).isEqualTo(5);
     }
 
     @Test
-    void givenAInvalidParameter_whenGetWQOffenceNewOffenceCountIsInvoked_thenNullIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(0);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
-        long offenceCount = courtDataAPIService.getWQOffenceNewOffenceCount(
-                TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
-        );
-        assertThat(offenceCount).isZero();
-    }
-
-    @Test
-    void givenAInvalidParameter_whenGetWQOffenceNewOffenceCountIsInvoked_thenEmptyIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(0);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
+    void givenAInvalidParameter_whenGetWQOffenceNewOffenceCountIsInvoked_thenReturnZero() {
+        when(maatAPIClient.get(any(), anyString(), any(Object[].class)))
+                .thenReturn(0);
         long offenceCount = courtDataAPIService.getWQOffenceNewOffenceCount(
                 TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
         );
@@ -185,11 +153,8 @@ class CourtDataAPIServiceTest {
 
     @Test
     void givenAValidParameter_whenGetWQOffenceNewOffenceCountIsInvoked_thenResponseIsReturned() {
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setContentLength(5);
-        ResponseEntity<Void> expected = ResponseEntity.ok().headers(responseHeaders).build();
-        when(maatAPIClient.head(any(), anyMap(), any(), any()))
-                .thenReturn(expected);
+        when(maatAPIClient.get(any(), anyString(), any(Object[].class)))
+                .thenReturn(5);
         long offenceCount = courtDataAPIService.getWQOffenceNewOffenceCount(
                 TestModelDataBuilder.TEST_CASE_ID, TestModelDataBuilder.TEST_OFFENCE_ID
         );

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
@@ -62,17 +62,6 @@ class MaatCourtDataServiceTest {
     }
 
     @Test
-    void givenAValidRequest_whenUpdateRepOrderIsInvoked_thenResponseIsReturned() {
-        maatCourtDataService.updateRepOrder(UpdateRepOrderRequestDTO.builder().build());
-        verify(maatAPIClient).put(
-                any(UpdateRepOrderRequestDTO.class),
-                any(),
-                anyString(),
-                anyMap()
-        );
-    }
-
-    @Test
     void givenAValidRepId_whenGetRepOrderCCOutcomeByRepIdIsInvoked_thenReturnOutcome() {
         maatCourtDataService.getRepOrderCCOutcomeByRepId(TestModelDataBuilder.TEST_REP_ID);
         verify(maatAPIClient, atLeastOnce()).get(any(), anyString(), anyMap(), any());

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
@@ -1,5 +1,14 @@
 package uk.gov.justice.laa.crime.crowncourt.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,6 +16,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.justice.laa.crime.commons.client.RestAPIClient;
@@ -17,11 +27,6 @@ import uk.gov.justice.laa.crime.crowncourt.data.builder.TestModelDataBuilder;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.IOJAppealDTO;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.RepOrderCCOutcomeDTO;
 import uk.gov.justice.laa.crime.crowncourt.dto.maatcourtdata.UpdateRepOrderRequestDTO;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 @ExtendWith(SoftAssertionsExtension.class)
@@ -80,7 +85,8 @@ class MaatCourtDataServiceTest {
 
     @Test
     void givenAInvalidParameter_whenGetRepOrderCCOutcomeByRepIdIsInvoked_thenReturnError() {
-        when(maatAPIClient.get(any(), anyString(), anyMap(), any())).thenThrow(new APIClientException());
+        when(maatAPIClient.get(any(), anyString(), anyMap(), any()))
+                .thenThrow(new APIClientException());
         assertThatThrownBy(() -> maatCourtDataService.getRepOrderCCOutcomeByRepId(
                 TestModelDataBuilder.TEST_REP_ID)
         ).isInstanceOf(APIClientException.class);
@@ -102,5 +108,15 @@ class MaatCourtDataServiceTest {
         assertThatThrownBy(() -> maatCourtDataService.outcomeCount(
                 TestModelDataBuilder.TEST_REP_ID)
         ).isInstanceOf(APIClientException.class);
+    }
+
+    @Test
+    void givenAValidEvidenceFeeRequest_whenGetCalEvidenceFeeIsInvokedAndNullIsReturned_then0IsReturned() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("X-Total-Records", "0");
+        ResponseEntity<Void> response = new ResponseEntity<>(null, headers, HttpStatus.OK);
+        when(maatAPIClient.head(any(), any(), any())).thenReturn(response);
+        long outcomeCount = maatCourtDataService.outcomeCount(TestModelDataBuilder.TEST_REP_ID);
+        assertThat(outcomeCount).isZero();
     }
 }

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MaatCourtDataServiceTest.java
@@ -111,7 +111,7 @@ class MaatCourtDataServiceTest {
     }
 
     @Test
-    void givenAValidEvidenceFeeRequest_whenGetCalEvidenceFeeIsInvokedAndNullIsReturned_then0IsReturned() {
+    void givenAValidEvidenceFeeRequest_whenOutcomeCountIsInvokedAndNullIsReturned_then0IsReturned() {
         HttpHeaders headers = new HttpHeaders();
         headers.add("X-Total-Records", "0");
         ResponseEntity<Void> response = new ResponseEntity<>(null, headers, HttpStatus.OK);

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
@@ -35,8 +35,10 @@ class RepOrderServiceTest {
 
     @InjectSoftAssertions
     private SoftAssertions softly;
+
     @InjectMocks
     private RepOrderService repOrderService;
+
     @Mock
     private MaatCourtDataService maatCourtDataService;
 
@@ -864,7 +866,6 @@ class RepOrderServiceTest {
     void givenAValidCrownCourtInput_whenOutcomeCountIsNotZero_thenReturnEmptyRepOrder() {
         when(maatCourtDataService.outcomeCount(any())).thenReturn(1L);
         RepOrderDTO repOrderDTO = repOrderService.updateCCOutcome(TestModelDataBuilder.getCrownCourtDTO());
-        verify(maatCourtDataService, atLeastOnce()).outcomeCount(any());
         assertThat(repOrderDTO).isNull();
     }
 
@@ -874,7 +875,6 @@ class RepOrderServiceTest {
         CrownCourtDTO crownCourtDTO = TestModelDataBuilder.getCrownCourtDTO();
         crownCourtDTO.getCrownCourtSummary().setCrownCourtOutcome(null);
         RepOrderDTO repOrderDTO = repOrderService.updateCCOutcome(crownCourtDTO);
-        verify(maatCourtDataService, atLeastOnce()).outcomeCount(any());
         assertThat(repOrderDTO).isNull();
     }
 
@@ -884,7 +884,6 @@ class RepOrderServiceTest {
         CrownCourtDTO crownCourtDTO = TestModelDataBuilder.getCrownCourtDTO();
         crownCourtDTO.getCrownCourtSummary().setCrownCourtOutcome(new ArrayList<>());
         RepOrderDTO repOrderDTO = repOrderService.updateCCOutcome(crownCourtDTO);
-        verify(maatCourtDataService, atLeastOnce()).outcomeCount(any());
         assertThat(repOrderDTO).isNull();
     }
 
@@ -896,7 +895,6 @@ class RepOrderServiceTest {
         when(crimeEvidenceDataService.getCalEvidenceFee(any())).thenReturn(new ApiCalculateEvidenceFeeResponse());
         when(maatCourtDataService.updateRepOrder(any())).thenReturn(TestModelDataBuilder.getRepOrderDTO());
         RepOrderDTO repOrderDTO = repOrderService.updateCCOutcome(crownCourtDTO);
-        verify(maatCourtDataService, atLeastOnce()).outcomeCount(any());
         verify(crimeEvidenceDataService).getCalEvidenceFee(any());
         verify(maatCourtDataService).updateRepOrder(any());
         verify(maatCourtDataService).createOutcome(any());
@@ -912,7 +910,6 @@ class RepOrderServiceTest {
                 .thenReturn(TestModelDataBuilder.getApiCalculateEvidenceFeeResponse());
         when(maatCourtDataService.updateRepOrder(any())).thenReturn(TestModelDataBuilder.getRepOrderDTO());
         RepOrderDTO repOrderDTO = repOrderService.updateCCOutcome(crownCourtDTO);
-        verify(maatCourtDataService, atLeastOnce()).outcomeCount(any());
         verify(crimeEvidenceDataService).getCalEvidenceFee(any());
         verify(maatCourtDataService).updateRepOrder(any());
         verify(maatCourtDataService).createOutcome(any());

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/RepOrderServiceTest.java
@@ -316,7 +316,6 @@ class RepOrderServiceTest {
                  * Scenario 4: APPEAL_CC case with MagCourtOutcome of COMMITTED_FOR_TRIAL.
                  * - Initial assessment passes.
                  * - Full assessment is in progress.
-                 * - Hardship review passes.
                  * - Expected outcome: GRANTED_PASSED_MEANS_TEST.
                  */
                 Arguments.of(
@@ -326,7 +325,7 @@ class RepOrderServiceTest {
                         CurrentStatus.IN_PROGRESS,
                         InitAssessmentResult.PASS.getResult(),
                         null,
-                        ReviewResult.PASS,
+                        null,
                         Constants.GRANTED_PASSED_MEANS_TEST
                 ),
                 /*
@@ -367,17 +366,16 @@ class RepOrderServiceTest {
                  * Scenario 7: SUMMARY_ONLY case with MagCourtOutcome of SENT_FOR_TRIAL.
                  * - Initial assessment fails.
                  * - Full assessment is in progress.
-                 * - Hardship review fails.
                  * - Expected outcome: null (no decision granted).
                  */
                 Arguments.of(
                         CaseType.SUMMARY_ONLY,
                         MagCourtOutcome.SENT_FOR_TRIAL,
                         CurrentStatus.COMPLETE,
-                        CurrentStatus.IN_PROGRESS,
+                        null,
                         InitAssessmentResult.FAIL.getResult(),
                         null,
-                        ReviewResult.FAIL,
+                        null,
                         null
                 )
         );

--- a/crown-court-proceeding/src/test/resources/mappings/api_get_WqOffence_665421.json
+++ b/crown-court-proceeding/src/test/resources/mappings/api_get_WqOffence_665421.json
@@ -3,15 +3,16 @@
   "name": "api_internal_v1_assessment_WqOffence_ed0e9d59-cc1c-4869-8fcd-464caf770744_case_665421",
   "request": {
     "urlPath": "/api/internal/v1/assessment/wq-offence/ed0e9d59-cc1c-4869-8fcd-464caf770744/case/665421",
-    "method": "HEAD"
+    "method": "GET"
   },
   "response": {
     "status": 200,
+    "body": "1",
     "headers": {
       "Date": "Sun, 17 Sep 2023 15:49:40 GMT",
       "apigw-requestid": "LaHzQgKJLPEEM0g=",
       "X-Amzn-Trace-Id": "Root=1-65072014-07aac4f80f5ab22e0a86b626;",
-      "Content-Length": "1"
+      "Content-Type": "application/json"
     }
   },
   "uuid": "8a250d99-fe63-42ce-9768-c0ed7df7474c",

--- a/crown-court-proceeding/src/test/resources/mappings/api_get_offence_665421.json
+++ b/crown-court-proceeding/src/test/resources/mappings/api_get_offence_665421.json
@@ -3,15 +3,16 @@
   "name": "api_internal_v1_assessment_offence_ed0e9d59-cc1c-4869-8fcd-464caf770744_case_665421",
   "request": {
     "urlPath": "/api/internal/v1/assessment/offence/ed0e9d59-cc1c-4869-8fcd-464caf770744/case/665421",
-    "method": "HEAD"
+    "method": "GET"
   },
   "response": {
     "status": 200,
+    "body": "1",
     "headers": {
       "Date": "Sun, 17 Sep 2023 15:49:40 GMT",
       "apigw-requestid": "LaHzQgKJLPEEM0g=",
       "X-Amzn-Trace-Id": "Root=1-65072014-07aac4f80f5ab22e0a86b626;",
-      "Content-Length": "1"
+      "Content-Type": "application/json"
     }
   },
   "uuid": "8a250d99-fe63-42ce-9768-c0ed7df7474c",


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1789)

**1. Refactored `MaatCourtDataService`**

- Due to a recent change in the Court Data API we now return a custom `X-Total-Records` header instead of `Content-Length` when retrieving the outcome count. This commit updates our header extraction logic by replacing `response.getHeaders().getContentLength()` with retrieval of the `X-Total-Records` header using `getFirst()`, along with a null-check and conversion to long. This aligns our client with the updated service contract.

**2. Refactored `CourtDataAPIService` (used in queue)**

- Replaced the `HEAD` requests (which returned the count via the `Content-Length` header as a Long)
with a `GET` request that directly returns the count as an `Integer`. This simplifies the logic
and clarifies the intent of the `getOffenceNewOffenceCount`  and `getWQOffenceNewOffenceCount` methods.
- This reflects a recent change in the Court Data API and aligns the client with the updated service contract.

**3. Refactored `ProsecutionConcludedController`**

- Switch `getCountByMaatIdAndStatus` endpoint from `HEAD` to `GET`, return count in body
- Removed the custom `Content-Length` header and now return the count as a plain number in the response body.
- Updated unit and integration tests to reflect the new behaviour.

**4. Testing improvements**

- Removed redundant verify checks in test cases.
- Replaced duplicate test cases with new `ParameterizedTest` and consolidated several others.
- Improve coverage and improve test method naming.

**NOTE: This PR is dependent upon [these](https://github.com/ministryofjustice/laa-maat-court-data-api/pull/1105) changes to the Court Data API.**

