### PR TITLE
[LASB-4103] Add ModSecurity config for the non-prod environments

### DIFF
--- a/helm_deploy/laa-crown-court-proceeding/values-dev.yaml
+++ b/helm_deploy/laa-crown-court-proceeding/values-dev.yaml
@@ -51,12 +51,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-proceeding-dev"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-proceeding-dev.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crown-court-proceeding/values-test.yaml
+++ b/helm_deploy/laa-crown-court-proceeding/values-test.yaml
@@ -51,12 +51,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-proceeding-test"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-proceeding-test.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false

--- a/helm_deploy/laa-crown-court-proceeding/values-uat.yaml
+++ b/helm_deploy/laa-crown-court-proceeding/values-uat.yaml
@@ -51,12 +51,17 @@ ingress:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-max-age: "300"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=laa-crime-apps-team,tag:namespace=laa-crown-court-proceeding-uat"
   externalAnnotations: {}
   hosts:
     - host: laa-crown-court-proceeding-uat.apps.live.cloud-platform.service.justice.gov.uk
       paths: ["/"]
   tls: []
-  className: default
+  className: modsec-non-prod
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LASB-4103)

Added ModSecurity to non-prod.

Please note, with the ModSecurity I have set it to DetectionOnly - This means requests won't be blocked, but will still be logged. This way we can monitor for a while and ensure it's not causing any false-positives before we start blocking requests.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.