### PR TITLE
Format Code Fix

### DIFF
--- a/.github/workflows/format-code.yml
+++ b/.github/workflows/format-code.yml
@@ -6,8 +6,8 @@ jobs:
   format-code:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@main
-      - uses: ministryofjustice/github-actions/code-formatter@main
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ministryofjustice/github-actions/code-formatter@db1a54895bf5fb975c60af47e5a3aab96505ca3e  # 18.6.0
         with:
           ignore-files: "docker-compose.override.yml,values-dev.yaml,values-test.yaml,values-uat.yaml,values-prod.yaml,ingress.yaml,scheduled-downtime-cronjob.yaml"
         env:


### PR DESCRIPTION
## What

Setting version of format code to newest release that still contains the action.
It will throw an error each time this action is attempted to run, which will cause a failure mark on the build.

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.