### PR TITLE
LCAM-4452-removed scheduler annotation

### DIFF
--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/scheduler/PurgeProsecutionConcludedScheduler.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/prosecution_concluded/scheduler/PurgeProsecutionConcludedScheduler.java
@@ -17,7 +17,7 @@ public class PurgeProsecutionConcludedScheduler {
 
     private final QueueMessageLogService queueMessageLogService;
 
-    @Scheduled(cron = "${queue.message.purge.cron.expression}")
+    //@Scheduled(cron = "${queue.message.purge.cron.expression}")
     public void purgePeriodicMessages() {
         log.info("Purge Prosecution concluded Scheduling is started");
         queueMessageLogService.purgePeriodicMessages();


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-4452)

Remove purge job as memory OutOfMemoryError in prod.  

## Checklist

Before you ask people to review this PR:

- [ ] Tests should be passing: `./gradlew test`
- [ ] GitHub should not be reporting conflicts; you should have recently run `git rebase main`.
- [ ] Avoid mixing whitespace changes with code changes in the same commit. These make diffs harder to read and conflicts more likely.
- [ ] You should have looked at the diff against main and ensured that nothing unexpected is included in your changes.
- [ ] You should have checked that the commit messages say why the change was made.

## Additional checks

- Don’t forget to [run](https://github.com/ministryofjustice/laa-crimeapps-maat-functional-tests/actions/workflows/ExecuteUiTests.yaml) the MAAT functional test suite after deploying your changes to the DEV or TEST environments to ensure your changes haven’t broken any of the functional tests.