### PR TITLE
[LCAM-1734] Add blank check to IoJ Summary decision result

### DIFF
--- a/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingService.java
+++ b/crown-court-proceeding/src/main/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingService.java
@@ -36,7 +36,10 @@ public class MagsProceedingService {
     public MagsDecisionResult determineMagsRepDecision(CrownCourtDTO dto) {
         ApiIOJSummary iojSummary = dto.getIojSummary();
         ReviewResult iojResult = ReviewResult.getFrom(
-                iojSummary.getDecisionResult() != null ? iojSummary.getDecisionResult() : iojSummary.getIojResult());
+                (iojSummary.getDecisionResult() != null
+                                && !iojSummary.getDecisionResult().isBlank())
+                        ? iojSummary.getDecisionResult()
+                        : iojSummary.getIojResult());
         boolean isMagsCourt = magsCourtCaseTypes.contains(dto.getCaseType());
         if (iojResult != null && isMagsCourt) {
             DecisionReason decisionReason = getDecisionReason(dto, iojResult);

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
@@ -208,6 +208,27 @@ class MagsProceedingServiceTest {
     }
 
     @Test
+    void givenBlankIojDecisionResult_whenDetermineMagsRepDecisionIsInvoked_thenReturnMagsDecisionResult() {
+        // given
+        CrownCourtDTO crownCourtDTO =
+                buildCrownCourtDTO(new Scenario(ReviewResult.PASS, null, null, ReviewResult.PASS, null));
+        crownCourtDTO.getIojSummary().setIojResult("PASS");
+        crownCourtDTO.getIojSummary().setDecisionResult("");
+
+        // when
+        when(maatCourtDataService.updateRepOrder(any(UpdateRepOrderRequestDTO.class)))
+                .thenReturn(RepOrderDTO.builder()
+                        .dateModified(TestModelDataBuilder.TEST_DATE_MODIFIED)
+                        .build());
+
+        MagsDecisionResult decisionResult = magsProceedingService.determineMagsRepDecision(crownCourtDTO);
+        // then
+        softly.assertThat(decisionResult.getDecisionDate()).isNotNull();
+        softly.assertThat(decisionResult.getDecisionReason()).isEqualTo(DecisionReason.GRANTED);
+        softly.assertThat(decisionResult.getTimestamp()).isEqualTo(TestModelDataBuilder.TEST_DATE_MODIFIED);
+    }
+
+    @Test
     void givenPassedIojResultAndCrownCourtCaseType_whenDetermineMagsRepDecisionIsInvoked_thenReturnNull() {
         // given
         CrownCourtDTO crownCourtDTO = CrownCourtDTO.builder()

--- a/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
+++ b/crown-court-proceeding/src/test/java/uk/gov/justice/laa/crime/crowncourt/service/MagsProceedingServiceTest.java
@@ -74,6 +74,7 @@ class MagsProceedingServiceTest {
         }
 
         softly.assertThat(crownCourtDTO.getMagsDecisionResult()).isEqualTo(decisionResult);
+        softly.assertAll();
 
         if (expectedResult != null) {
             verify(maatCourtDataService).updateRepOrder(any(UpdateRepOrderRequestDTO.class));
@@ -226,6 +227,7 @@ class MagsProceedingServiceTest {
         softly.assertThat(decisionResult.getDecisionDate()).isNotNull();
         softly.assertThat(decisionResult.getDecisionReason()).isEqualTo(DecisionReason.GRANTED);
         softly.assertThat(decisionResult.getTimestamp()).isEqualTo(TestModelDataBuilder.TEST_DATE_MODIFIED);
+        softly.assertAll();
     }
 
     @Test
@@ -265,6 +267,7 @@ class MagsProceedingServiceTest {
 
         softly.assertThat(decisionResult).isNull();
         softly.assertThat(crownCourtDTO.getMagsDecisionResult()).isNull();
+        softly.assertAll();
 
         verify(maatCourtDataService, never()).updateRepOrder(any(UpdateRepOrderRequestDTO.class));
     }


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-1734)

This issue was discovered as part of submitting a Hardship review without an IoJ Appeal. If a blank string is sent through for the decisionResult, this conditional would be true (as a blank string is not null) and the iojResult would be set to an empty value. This prevented the Rep Order Decision from being updated when a Hardship review was submitted.