### PR TITLE
LCAM-2128: update springboot/tomcat dependencies for CVE

### DIFF
--- a/crown-court-proceeding/build.gradle
+++ b/crown-court-proceeding/build.gradle
@@ -9,7 +9,7 @@ plugins {
 }
 
 // springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
-// ext['tomcat.version'] = '10.1.55'
+ext['tomcat.version'] = '10.1.55'
 
 group = "uk.gov.justice.laa.crime"
 

--- a/crown-court-proceeding/build.gradle
+++ b/crown-court-proceeding/build.gradle
@@ -8,6 +8,9 @@ plugins {
     id "io.spring.dependency-management" version "1.1.7"
 }
 
+// springboot tomcat version overide, can be removed when springboot is 3.5.15 or 4+
+// ext['tomcat.version'] = '10.1.55'
+
 group = "uk.gov.justice.laa.crime"
 
 jacoco {
@@ -52,7 +55,7 @@ sourceSets {
 repositories {
     mavenCentral()
     maven {
-        url 'https://central.sonatype.com/repository/maven-snapshots/'
+        url = 'https://central.sonatype.com/repository/maven-snapshots/'
     }
 }
 
@@ -98,9 +101,6 @@ dependencies {
     compileOnly "org.projectlombok:lombok"
     annotationProcessor "org.projectlombok:lombok"
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-
-    // ---- Pinned to Resolve Vulnerability CVE-2026-43512 ---
-    implementation "org.apache.tomcat.embed:tomcat-embed-core:10.1.55"
 
     // ---- Testing ----
     testImplementation "com.h2database:h2"


### PR DESCRIPTION
## What

[Link to story](https://dsdmoj.atlassian.net/browse/LCAM-2107)

update springboot and tomcat versions to fix reported CVE
springboot:3.5.14
tomcat: 10.1.55
Builds successfully, no SYNK warnings

[failing build](https://app.circleci.com/pipelines/github/ministryofjustice/laa-crown-court-proceeding/1578/workflows/842f6815-d6dd-4e63-a6dd-799f2719903c/jobs/8846)
[passing build](https://app.circleci.com/pipelines/github/ministryofjustice/laa-crown-court-proceeding/1579/workflows/13751e65-ecb7-4074-94a1-5c7eb38c1064/jobs/8854)
